### PR TITLE
Agrega url de tv show

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
    "description": "Premium en ovacion, elpais y el observador",
    "content_scripts": [
      {
-       "matches": ["*://*.elobservador.com.uy/*", "*://*.elpais.com.uy/*", "https://*.ovaciondigital.com.uy/*"],
+       "matches": ["*://*.elobservador.com.uy/*", "*://*.elpais.com.uy/*", "https://*.ovaciondigital.com.uy/*",  "*://*.tvshow.com.uy/*"],
        "js": ["extension.js"],
        "run_at": "document_end"
      }


### PR DESCRIPTION
Agrega al mainfest.json la url de tvshow para que funcione en esa página.

.
PD: (quería saber por que mauro icardi no juega y si wanda lo está cagando jajaj) 

Muy buena la extensión, muchas gracias por compartirla!